### PR TITLE
Add unit declarator to class declarations

### DIFF
--- a/lib/Math/Model.pm
+++ b/lib/Math/Model.pm
@@ -1,6 +1,6 @@
 use v6;
 
-class Math::Model;
+unit class Math::Model;
 
 use Math::RungeKutta;
 # TODO: only load when needed


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class`, `role` or `grammar` declarations (unless it uses a
block).  Code still using the old blockless semicolon form will throw a
warning. This commit stops the warning from appearing in the new Rakudo.