### PR TITLE
Replace lives_ok with kebab-case version

### DIFF
--- a/t/basic.t
+++ b/t/basic.t
@@ -4,7 +4,7 @@ use Test;
 use Math::Model;
 
 my $m;
-lives_ok {
+lives-ok {
     $m = Math::Model.new(
         derivatives => {
             a   => 'b',
@@ -20,7 +20,7 @@ lives_ok {
 }, 'can initialize a Math::Model';
 
 my %res;
-lives_ok { %res = $m.integrate(:from(0), :to(3)) }, 'can integrate the model';
+lives-ok { %res = $m.integrate(:from(0), :to(3)) }, 'can integrate the model';
 diag "result: %res.perl()";
 
 is %res<time>[0],   0, 'time starts at 0';


### PR DESCRIPTION
`lives_ok` has been deprecated in favour of `lives-ok`; the deprecated form
will be removed in the 2015.09 Rakudo release.